### PR TITLE
Added new layer auto-zooming and -styling methods

### DIFF
--- a/QGISVisualizationWidget.h
+++ b/QGISVisualizationWidget.h
@@ -39,6 +39,7 @@ UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 // Written by: Stevan Gavrilovic
 
 #include "VisualizationWidget.h"
+#include "qgssinglesymbolrenderer.h"
 
 #include <qgsfeatureid.h>
 #include <qgsgeometry.h>
@@ -113,6 +114,12 @@ public:
     SimCenterMapcanvasWidget* getMapViewWidget(const QString& name);
 
     void markDirty();
+
+    void zoomToExtent(QgsRectangle zoomRectangle);
+
+    void zoomToActiveLayer(void);
+
+    void setActiveLayerFillNull(void);
 
     void createSymbolRenderer(Qgis::MarkerShape symbolShape, QColor color, double size, QgsVectorLayer * layer);
 


### PR DESCRIPTION
Added three new methods.
`zoomToExtent`: Zooms the map to a rectangular bounding box. This can be used to initialize QGIS window zoomed into a place of interest (instead of the whole world)
`zoomToActiveLayer`: Provides the functionality of (right click)->Zoom to layer
`setActiveLayerFillNull`: Automatically sets the fill color to transparent, useful for visualizing bounding polygons